### PR TITLE
Expose status codes as `boom.STATUS_CODES`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ const internals = {
     }, null)
 };
 
+exports.STATUS_CODES = internals.STATUS_CODES;
 
 exports.wrap = function (error, statusCode, message) {
 


### PR DESCRIPTION
Useful for writing tests, or if you just want to have them as a dictionary.