### PR TITLE
Add Boom.internal() to API docs fixes #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ Generates the following response payload:
 
 All 500 errors hide your message from the end user. Your message is recorded in the server log.
 
-### `Boom.badImplementation([message], [data])`
+### `Boom.badImplementation([message], [data])` - (*alias: `internal`*)
 
 Returns a 500 Internal Server Error error where:
 - `message` - optional message.


### PR DESCRIPTION
I followed the [Joi API doc example](https://github.com/hapijs/joi/blob/v9.0.4/API.md#anyinvalidvalue---aliases-disallow-not) and added `internal` as an alias for `badImplementation` since the returned `statusCode` and `error` are the same.