### PR TITLE
Add 'allow' parameter to methodNotAllowed for setting 'Allow' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Generates the following response payload:
 Returns a 405 Method Not Allowed error where:
 - `message` - optional message.
 - `data` - optional additional error data.
-- `allow` can be either a string or an array of strings (to be combined and separated by ', ') which is set to the 'Allow' header.
+- `allow` - optional string or array of strings (to be combined and separated by ', ') which is set to the 'Allow' header.
 
 ```js
 Boom.methodNotAllowed('that method is not allowed');

--- a/README.md
+++ b/README.md
@@ -252,11 +252,12 @@ Generates the following response payload:
 }
 ```
 
-### `Boom.methodNotAllowed([message], [data])`
+### `Boom.methodNotAllowed([message], [data], [allow])`
 
 Returns a 405 Method Not Allowed error where:
 - `message` - optional message.
 - `data` - optional additional error data.
+- `allow` can be either a string or an array of strings (to be combined and separated by ', ') which is set to the 'Allow' header.
 
 ```js
 Boom.methodNotAllowed('that method is not allowed');

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,9 +238,19 @@ exports.notFound = function (message, data) {
 };
 
 
-exports.methodNotAllowed = function (message, data) {
+exports.methodNotAllowed = function (message, data, allow) {
 
-    return internals.create(405, message, data, exports.methodNotAllowed);
+    const err = internals.create(405, message, data, exports.methodNotAllowed);
+
+    if (typeof allow === 'string') {
+        allow = [allow];
+    }
+
+    if (Array.isArray(allow)) {
+        err.output.headers.Allow = allow.join(', ');
+    }
+
+    return err;
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -274,6 +274,28 @@ describe('methodNotAllowed()', () => {
         expect(Boom.methodNotAllowed('my message').message).to.equal('my message');
         done();
     });
+
+    it('sets the message with the passed in message', (done) => {
+
+        expect(Boom.methodNotAllowed('my message').message).to.equal('my message');
+        done();
+    });
+
+    it('returns an Allow header when passed a string', (done) => {
+
+        const err = Boom.methodNotAllowed('my message', null, 'GET');
+        expect(err.output.statusCode).to.equal(405);
+        expect(err.output.headers.Allow).to.equal('GET');
+        done();
+    });
+
+    it('returns an Allow header when passed an array', (done) => {
+
+        const err = Boom.methodNotAllowed('my message', null, ['GET', 'POST']);
+        expect(err.output.statusCode).to.equal(405);
+        expect(err.output.headers.Allow).to.equal('GET, POST');
+        done();
+    });
 });
 
 


### PR DESCRIPTION
Closes https://github.com/hapijs/boom/issues/132.

This PR adds an optional `allow` parameter to `Boom.methodNotAllowed`, which in turn sets the "Allow" header on the output, [as required in the spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6). It accepts either a string or an array of strings to be combined and comma-separated.