### PR TITLE
inline util fns, make this work w/ browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,6 @@
 'use strict';
 
-// Load modules
-
-const Hoek = require('hoek');
-
-
 // Declare internals
-
 const internals = {
     STATUS_CODES: Object.setPrototypeOf({
         '100': 'Continue',
@@ -69,10 +63,20 @@ const internals = {
     }, null)
 };
 
+const escapeHeaderAttribute = function (attribute) {
+    // Allowed value characters: !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9, \, "
+    if (!/^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~\"\\]*$/.test(attribute)) {
+        throw new Error('Bad attribute value (' + attribute + ')');
+    }
+
+    return attribute.replace(/\\/g, '\\\\').replace(/\"/g, '\\"');                             // Escape quotes and slash
+};
 
 exports.wrap = function (error, statusCode, message) {
 
-    Hoek.assert(error instanceof Error, 'Cannot wrap non-Error object');
+    if (!(error instanceof Error)) {
+        throw new Error('Cannot wrap non-Error object');
+    }
     return (error.isBoom ? error : internals.initialize(error, statusCode || 500, message));
 };
 
@@ -96,7 +100,9 @@ internals.create = function (statusCode, message, data, ctor) {
 internals.initialize = function (error, statusCode, message) {
 
     const numberCode = parseInt(statusCode, 10);
-    Hoek.assert(!isNaN(numberCode) && numberCode >= 400, 'First argument must be a number (400+):', statusCode);
+    if (isNaN(numberCode) || numberCode < 400) {
+        throw new Error('First argument must be a number (400+): ' + statusCode);
+    }
 
     error.isBoom = true;
     error.isServer = numberCode >= 500;
@@ -184,7 +190,7 @@ exports.unauthorized = function (message, scheme, attributes) {          // Or f
 
                     value = '';
                 }
-                wwwAuthenticate = wwwAuthenticate + ' ' + name + '="' + Hoek.escapeHeaderAttribute(value.toString()) + '"';
+                wwwAuthenticate = wwwAuthenticate + ' ' + name + '="' + escapeHeaderAttribute(value.toString()) + '"';
                 err.output.payload.attributes[name] = value;
             }
         }
@@ -193,7 +199,7 @@ exports.unauthorized = function (message, scheme, attributes) {          // Or f
             if (attributes) {
                 wwwAuthenticate = wwwAuthenticate + ',';
             }
-            wwwAuthenticate = wwwAuthenticate + ' error="' + Hoek.escapeHeaderAttribute(message) + '"';
+            wwwAuthenticate = wwwAuthenticate + ' error="' + escapeHeaderAttribute(message) + '"';
             err.output.payload.attributes.error = message;
         }
         else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "hoek": "4.x.x"
   },
   "devDependencies": {
     "code": "3.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,12 @@ it('sets new message when none exists', (done) => {
     done();
 });
 
+it('throws error if trying to wrap a non-Error', (done) => {
+
+    expect(() => Boom.wrap('foo')).to.throw('Cannot wrap non-Error object');
+    done();
+});
+
 it('throws when statusCode is not a number', (done) => {
 
     expect(() => {
@@ -97,7 +103,7 @@ it('throws when statusCode is not finite', (done) => {
     expect(() => {
 
         Boom.create(1 / 0);
-    }).to.throw('First argument must be a number (400+): null');
+    }).to.throw('First argument must be a number (400+): Infinity');
     done();
 });
 
@@ -204,6 +210,12 @@ describe('unauthorized()', () => {
         expect(err.output.statusCode).to.equal(401);
         expect(err.output.headers['WWW-Authenticate']).to.equal('Test a="1", b="something", c="", d="0", error="boom"');
         expect(err.output.payload.attributes).to.equal({ a: 1, b: 'something', c: '', d: 0, error: 'boom' });
+        done();
+    });
+
+    it('throws error for invalid attribute value', (done) => {
+
+        expect(() => Boom.unauthorized(null, 'Test', { a: 1, b: '\u1ed2', c: null, d: 0 })).to.throw('Bad attribute value (\u1ed2)');
         done();
     });
 


### PR DESCRIPTION
This PR essentially facilitate packaging tools like webpack/browserify. `hoek` imports in `crypto`, `path` & `util` so those have to be polyfilled while `boom` doesn't use them. 