### PR TITLE
Added typeOf functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,11 +99,12 @@ internals.create = function (statusCode, message, data, ctor) {
     Error.captureStackTrace(error, ctor);                           // Filter the stack to our external API
     error.data = data || null;
     internals.initialize(error, statusCode);
-    
+
     error.typeOf = (boomType) => {
+
         return boomType === ctor;
-    }
-    
+    };
+
     return error;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,11 @@ internals.create = function (statusCode, message, data, ctor) {
     Error.captureStackTrace(error, ctor);                           // Filter the stack to our external API
     error.data = data || null;
     internals.initialize(error, statusCode);
+    
+    error.typeOf = (boomType) => {
+        return boomType === ctor;
+    }
+    
     return error;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -835,3 +835,15 @@ describe('method with error object instead of message', () => {
         }
     });
 });
+
+describe('error.typeOf()', () => {
+
+    it('should support typeOf for boomTypes', (done) => {
+
+        const err = Boom.notFound('Something was not found');
+        expect(err.typeOf).to.exist();
+        expect(err.typeOf(Boom.notFound)).to.be.true();
+        expect(err.typeOf(Boom.badRequest)).to.be.false();
+        done();
+    });
+});


### PR DESCRIPTION
Hey guys,

This may be a special use case, but it makes for nice filtering of errors without having to deep check vs strings and numbers.

Although it doesn't satisfy the instanceof concern as seen here https://github.com/hapijs/boom/issues/101, it does make filtering manually cleaner.

Instead of having to do such things as:

```
import boom from "boom";

const err = boom.notFound("Something is not found");
if (err.isBoom && err.output.statusCode === 404) return; // true;
if (err.isBoom && err.output.payload.statusCode === 404) return; // true;
if (err.isBoom && err.output.payload.error === "Not Found") return; // true;
```

You can instead do:

```
import boom from "boom";

const err = boom.notFound("Something is not found");
if (err.isBoom && err.typeOf(boom.notFound)) return; // true;
```

This keeps the logic simpler and also prevents potential spelling errors, remembering status codes, and internal changes to the structure of the output.