### PR TITLE
Wrap should return the same object if already Boom

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,6 @@ const internals = {
 exports.wrap = function (error, statusCode, message) {
 
     Hoek.assert(error instanceof Error, 'Cannot wrap non-Error object');
-    Hoek.assert(!error.isBoom || (!statusCode && !message), 'Cannot provide statusCode or message with boom error');
 
     return (error.isBoom ? error : internals.initialize(error, statusCode || 500, message));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -25,15 +25,8 @@ it('returns the same object when already boom', (done) => {
     const error = Boom.badRequest();
     expect(error).to.equal(Boom.wrap(error));
     expect(error).to.equal(Boom.wrap(error, null, null));
-    done();
-});
-
-it('errors on wrap with boom error and additional arguments', (done) => {
-
-    const error = Boom.badRequest('Something');
-    expect(() => Boom.wrap(error, 401)).to.throw('Cannot provide statusCode or message with boom error');
-    expect(() => Boom.wrap(error, 402, 'Else')).to.throw('Cannot provide statusCode or message with boom error');
-    expect(() => Boom.wrap(error, undefined, 'Else')).to.throw('Cannot provide statusCode or message with boom error');
+    expect(error).to.equal(Boom.wrap(error, 999));
+    expect(error).to.equal(Boom.wrap(error, 999, 'Something'));
     done();
 });
 


### PR DESCRIPTION
Fixes #160 

Boom.wrap() of a Boom object should consistently return the original Boom object regardless of potentially supplied arguments.