### PR TITLE
 add in missing super() in constructor.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ module.exports = internals.Boom = class extends Error {
     }
 
     constructor(message, options = {}) {
-
+        super();
         if (message instanceof Error) {
             return internals.Boom.boomify(Hoek.clone(message), options);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ module.exports = internals.Boom = class extends Error {
     }
 
     constructor(message, options = {}) {
+
         super();
         if (message instanceof Error) {
             return internals.Boom.boomify(Hoek.clone(message), options);


### PR DESCRIPTION
Webpacking fails with Boom because the main class constructor is missing a super(). This patch fixes the issue.