### PR TITLE
Fixes  prototype pollution vulnerability on hoek dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "hoek": "5.x.x"
+    "hoek": ">=5.0.3"
   },
   "devDependencies": {
     "code": "5.x.x",


### PR DESCRIPTION
Fixes  prototype pollution vulnerability on hoek dependency  by bumping the version to 5.0.3

https://nodesecurity.io/advisories/566