### PR TITLE
Fix types: serviceUnavailable -> serverUnavailable.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -427,7 +427,7 @@ export class Boom<T = any> extends Error {
 
     @returns A 503 Service Unavailable error
     */
-    static serviceUnavailable<T>(message?: string, data?: T): Boom<T>
+    static serverUnavailable<T>(message?: string, data?: T): Boom<T>
 
     /**
     Returns a 504 Gateway Time-out error

--- a/test/index.ts
+++ b/test/index.ts
@@ -351,13 +351,13 @@ expect.error(Boom.badGateway({ foo: 'bar' }));
 
 // serverUnavailable()
 
-expect.type<Boom>(Boom.serviceUnavailable('unavailable', 'some data'));
-expect.type<Boom>(Boom.serviceUnavailable('unavailable', { foo: 'bar' }));
-expect.type<Boom>(Boom.serviceUnavailable('unavailable'));
-expect.type<Boom>(Boom.serviceUnavailable());
+expect.type<Boom>(Boom.serverUnavailable('unavailable', 'some data'));
+expect.type<Boom>(Boom.serverUnavailable('unavailable', { foo: 'bar' }));
+expect.type<Boom>(Boom.serverUnavailable('unavailable'));
+expect.type<Boom>(Boom.serverUnavailable());
 
-expect.error(Boom.serviceUnavailable(503));
-expect.error(Boom.serviceUnavailable({ foo: 'bar' }));
+expect.error(Boom.serverUnavailable(503));
+expect.error(Boom.serverUnavailable({ foo: 'bar' }));
 
 
 // gatewayTimeout()


### PR DESCRIPTION
Fixes #237

This fixes the types, but it's a little concerning that the tests didn't catch this. It seems they don't actually run the code? 

@jarrodyellets 
@hueniverse   

>  error TS2551: Property 'serverUnavailable' does not exist on type 'typeof Boom'. Did you mean 'serviceUnavailable'?