### PR TITLE
Fix types: Update static isBoom to be a type guard.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,7 @@ declare namespace boom {
 
     interface Payload {
         /**
-        The HTTP status code derived from error.output.statuscode
+        The HTTP status code derived from error.output.statusCode
         */
         statusCode: number
 
@@ -37,7 +37,7 @@ declare namespace boom {
     interface Options<Data, Decoration> {
         /**
         The HTTP status code
-    
+
         @default 500
         */
         statusCode?: number
@@ -59,14 +59,14 @@ declare namespace boom {
 
         /**
         Error message string
-    
+
         @default none
         */
         message?: string
 
         /**
         If false, the err provided is a Boom object, and a statusCode or message are provided, the values are ignored
-    
+
         @default true
         */
         override?: boolean
@@ -89,7 +89,7 @@ export class Boom<Data = any, Decoration = object> extends Error {
     /**
     Custom error data with additional information specific to the error type
     */
-    data: Data
+    data: Data;
 
     /** isBoom - if true, indicates this is a Boom object instance. */
     isBoom: boolean;
@@ -105,7 +105,7 @@ export class Boom<Data = any, Decoration = object> extends Error {
     message: string;
 
     /**
-    The formated response
+    The formatted response
     */
     output: boom.Output;
 
@@ -128,7 +128,7 @@ export class Boom<Data = any, Decoration = object> extends Error {
 
     @returns Returns a boolean stating if the error object is a valid boom object
     */
-    static isBoom(err: Error): boolean
+    static isBoom(err: Error): err is Boom
 
     /**
     Specifies if an error object is a valid boom object

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,7 +25,7 @@ const decorate = new X(1);
 
 // boomify()
 
-const error = new Error('Unexpected input')
+const error = new Error('Unexpected input');
 
 expect.type<Boom>(Boom.boomify(error, { statusCode: 400 }));
 expect.type<Boom>(Boom.boomify(error, { statusCode: 400, message: 'Unexpected Input', override: false }));
@@ -38,9 +38,14 @@ expect.error(Boom.boomify(error, { statusCode: 400, override: 'false' }));
 expect.error(Boom.boomify());
 
 
+// isBoom
+
+expect.type<boolean>(Boom.boomify(error).isBoom);
+
 // isBoom()
 
 expect.type<boolean>(Boom.isBoom(error));
+expect.type<boolean>(Boom.isBoom(Boom.boomify(error)));
 
 expect.error(Boom.isBoom('error'));
 expect.error(Boom.isBoom({ foo: 'bar' }));


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/advanced-types.html#typeof-type-guards

@hueniverse 