### PR TITLE
Fix CHANGELOG.md wrt. breaking changes label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-Breaking changes are documented using GitHub issues, see [issues labeled "release notes"](https://github.com/hapijs/boom/issues?q=is%3Aissue+label%3A%22release+notes%22).
+Breaking changes are documented using GitHub issues, see [issues labeled "breaking changes"](https://github.com/hapijs/boom/issues?q=is%3Aissue+label%3A%22breaking+changes%22).
 
 If you want changes of a specific minor or patch release, you can browse the [GitHub milestones](https://github.com/hapijs/boom/milestones?state=closed&direction=asc&sort=due_date).


### PR DESCRIPTION
As far as I can tell, breaking changes are documented via the GitHub issue label "breaking changes". Fix CHANGELOG.md to reflect this.

Looking at another Hapi repo though, [joi](https://github.com/hapijs/joi), I see that it also uses "release notes" in CHANGELOG.md to refer to breaking changes, but in that repo it actually seems consistent (although "breaking changes" are also used there). What should the procedure actually be, identifying breaking changes through "release notes" or "breaking changes"?