### PR TITLE
Add HTTP code 425 Too Early

### DIFF
--- a/API.md
+++ b/API.md
@@ -584,6 +584,26 @@ Generates the following response payload:
 }
 ```
 
+##### `Boom.tooEarly([message], [data])`
+
+Returns a 425 Too Early error where:
+- `message` - optional message.
+- `data` - optional additional error data.
+
+```js
+Boom.tooEarly('the server is unwilling to risk processing the request');
+```
+
+Generates the following response payload:
+
+```json
+{
+    "statusCode": 425,
+    "error": "Too Early",
+    "message": "the server is unwilling to risk processing the request"
+}
+```
+
 ##### `Boom.preconditionRequired([message], [data])`
 
 Returns a 428 Precondition Required error where:

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -430,6 +430,16 @@ export function locked<Data>(message?: string, data?: Data): Boom<Data>;
 */
 export function failedDependency<Data>(message?: string, data?: Data): Boom<Data>;
 
+/**
+* Returns a 425 Too Early error
+*
+* @param message - Optional message
+* @param data - Optional additional error data
+*
+* @returns A 425 Too Early error
+*/
+export function tooEarly<Data>(message?: string, data?: Data): Boom<Data>;
+
 
 /**
 * Returns a 428 Precondition Required error

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ const internals = {
         [422, 'Unprocessable Entity'],
         [423, 'Locked'],
         [424, 'Failed Dependency'],
-        [425, 'Unordered Collection'],
+        [425, 'Too Early'],
         [426, 'Upgrade Required'],
         [428, 'Precondition Required'],
         [429, 'Too Many Requests'],
@@ -331,6 +331,11 @@ exports.locked = function (message, data) {
 exports.failedDependency = function (message, data) {
 
     return new exports.Boom(message, { statusCode: 424, data, ctor: exports.failedDependency });
+};
+
+exports.tooEarly = function (message, data) {
+
+    return new exports.Boom(message, { statusCode: 425, data, ctor: exports.tooEarly });
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -675,6 +675,19 @@ describe('Boom', () => {
         });
     });
 
+    describe('tooEarly()', () => {
+
+        it('returns a 425 error statusCode', () => {
+
+            expect(Boom.tooEarly().output.statusCode).to.equal(425);
+        });
+
+        it('sets the message with the passed in message', () => {
+
+            expect(Boom.tooEarly('my message').message).to.equal('my message');
+        });
+    });
+
 
     describe('preconditionRequired()', () => {
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -319,6 +319,14 @@ expect.type<Boom.Boom>(Boom.failedDependency());
 expect.error(Boom.failedDependency(424));
 expect.error(Boom.failedDependency({ foo: 'bar' }));
 
+// tooEarly()
+expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request', 'some data'));
+expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request', { foo: 'bar' }));
+expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request'));
+expect.type<Boom.Boom>(Boom.tooEarly());
+
+expect.error(Boom.tooEarly(425));
+expect.error(Boom.tooEarly({ foo: 'bar' }));
 
 // preconditionRequired()
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -320,6 +320,7 @@ expect.error(Boom.failedDependency(424));
 expect.error(Boom.failedDependency({ foo: 'bar' }));
 
 // tooEarly()
+
 expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request', 'some data'));
 expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request', { foo: 'bar' }));
 expect.type<Boom.Boom>(Boom.tooEarly('won\'t process your request'));


### PR DESCRIPTION
Hi! I read that the status 425 code refers to `Too Early` so I made this small contribution if you don't mind.

References:
* [RFC 8470](https://tools.ietf.org/html/rfc8470#section-5.2)
* [MDN: 425 Too Early](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425)