### PR TITLE
Docs: Clarify usage with `instanceof`

### DIFF
--- a/API.md
+++ b/API.md
@@ -69,7 +69,7 @@ Boom.boomify(error, { statusCode: 400 });
 
 ##### `isBoom(err, statusCode)`
 
-Identifies whether an error is a `Boom` object. Same as calling `instanceof Boom`.
+Identifies whether an error is a `Boom` object. Same as calling `instanceof Boom.Boom`.
 - `err` - Error object.
 - `statusCode` - optional status code.
 


### PR DESCRIPTION
The `instanceof` check needs to be called with `Boom.Boom` since `Boom` is not a constructor. Calling `err instanceof Boom` throws `TypeError: Right-hand side of 'instanceof' is not callable`