### PR TITLE
Make isBoom type definition laxer

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -127,14 +127,14 @@ export interface Output {
 
 
 /**
-* Specifies if an error object is a valid boom object
+* Specifies if an object is a valid boom object
 *
-* @param err - The error object
+* @param obj - The object to assess
 * @param statusCode - Optional status code
 *
 * @returns Returns a boolean stating if the error object is a valid boom object and it has the provided statusCode (if present)
 */
-export function isBoom(err: Error, statusCode?: number): err is Boom;
+export function isBoom(obj: unknown, statusCode?: number): obj is Boom;
 
 
 /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -60,11 +60,11 @@ expect.type<boolean>(Boom.boomify(error).isBoom);
 expect.type<boolean>(Boom.isBoom(error));
 expect.type<boolean>(Boom.isBoom(error, 404));
 expect.type<boolean>(Boom.isBoom(Boom.boomify(error)));
+expect.type<boolean>(Boom.isBoom('error'));
+expect.type<boolean>(Boom.isBoom({ foo: 'bar' }));
+expect.type<boolean>(Boom.isBoom({ error: true }));
 
 expect.error(Boom.isBoom(error, 'test'));
-expect.error(Boom.isBoom('error'));
-expect.error(Boom.isBoom({ foo: 'bar' }));
-expect.error(Boom.isBoom({ error: true }));
 expect.error(Boom.isBoom());
 
 


### PR DESCRIPTION
Especially useful in hapijs context, where request.response can be a
Boom object. This change allows the TypeScript code to leverage isBoom()
to check if request.response is a Boom object or not, without any noisy typecast.