### PR TITLE
TypeScript: Allow custom properties on output.payload

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -105,6 +105,11 @@ export interface Payload {
     The error message derived from error.message
     */
     message: string;
+
+    /**
+     * Custom properties
+     */
+    [key: string]: unknown;
 }
 
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -32,6 +32,11 @@ expect.type<Boom.Boom>(new CustomError('Some error'));
 
 const boom = new Boom.Boom('some error');
 expect.type<Boom.Output>(boom.output);
+boom.output.payload.custom_null = null;
+boom.output.payload.custom_number = 42;
+boom.output.payload.custom_string = 'foo';
+boom.output.payload.custom_boolean = true;
+boom.output.payload.custom_object = { bar: 42 };
 expect.type<Boom.Payload>(boom.output.payload);
 
 


### PR DESCRIPTION
Fixes #277