### PR TITLE
Add proper index type to headers property

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -122,7 +122,7 @@ export interface Output {
     /**
      * An object containing any HTTP headers where each key is a header name and value is the header content
      */
-    headers: object;
+    headers: { [header: string]: string | string[] | number | undefined };
 
     /**
      * The formatted object used as the response payload (stringified)

--- a/test/index.ts
+++ b/test/index.ts
@@ -37,7 +37,12 @@ boom.output.payload.custom_number = 42;
 boom.output.payload.custom_string = 'foo';
 boom.output.payload.custom_boolean = true;
 boom.output.payload.custom_object = { bar: 42 };
+boom.output.headers['header1'] = 'foo';
+boom.output.headers['header2'] = ['foo', 'bar'];
+boom.output.headers['header3'] = 42;
+boom.output.headers['header4'] = undefined;
 expect.type<Boom.Payload>(boom.output.payload);
+expect.type<Boom.Output['headers']>(boom.output.headers);
 
 
 // boomify()


### PR DESCRIPTION
`object` doesn't allow properly looking up values on `headers` (for example, `headers['Authorization']` will be rejected by Typescript). Using `Partial<Record<string, string>>` allows this lookup and accounts for potentially undefined headers.