### PR TITLE
Don't mess with instanceof checks called on subclasses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,13 @@ exports.Boom = class extends Error {
 
     static [Symbol.hasInstance](instance) {
 
-        return exports.isBoom(instance);
+        if (this === exports.Boom) {
+            return exports.isBoom(instance);
+        }
+
+        // Cannot use 'instanceof' as it creates infinite recursion
+
+        return this.prototype.isPrototypeOf(instance);
     }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -129,23 +129,30 @@ describe('Boom', () => {
 
             const BadaBoom = class extends Boom.Boom { };
 
-            expect(new Boom.Boom('oops') instanceof Boom.Boom).to.be.true();
-            expect(new BadaBoom('oops') instanceof Boom.Boom).to.be.true();
-            expect(Boom.badRequest('oops') instanceof Boom.Boom).to.be.true();
-            expect(new Error('oops') instanceof Boom.Boom).to.be.false();
-            expect(Boom.boomify(new Error('oops')) instanceof Boom.Boom).to.be.true();
-            expect({ isBoom: true } instanceof Boom.Boom).to.be.false();
-            expect(null instanceof Boom.Boom).to.be.false();
+            expect(new Boom.Boom('oops')).to.be.instanceOf(Boom.Boom);
+            expect(new BadaBoom('oops')).to.be.instanceOf(Boom.Boom);
+            expect(Boom.badRequest('oops')).to.be.instanceOf(Boom.Boom);
+            expect(new Error('oops')).to.not.be.instanceOf(Boom.Boom);
+            expect(Boom.boomify(new Error('oops'))).to.be.instanceOf(Boom.Boom);
+            expect({ isBoom: true }).to.not.be.instanceOf(Boom.Boom);
+            expect(null).to.not.be.instanceOf(Boom.Boom);
         });
 
         it('returns false when called on sub-class', () => {
 
             const BadaBoom = class extends Boom.Boom {};
 
-            expect(new Boom.Boom('oops') instanceof BadaBoom).to.be.false();
-            expect(new BadaBoom('oops') instanceof BadaBoom).to.be.false();
-            expect(Boom.badRequest('oops') instanceof BadaBoom).to.be.false();
-            expect(Boom.boomify(new Error('oops')) instanceof BadaBoom).to.be.false();
+            expect(new Boom.Boom('oops')).to.not.be.instanceOf(BadaBoom);
+            expect(new BadaBoom('oops')).to.not.be.instanceOf(BadaBoom);
+            expect(Boom.badRequest('oops')).to.not.be.instanceOf(BadaBoom);
+            expect(Boom.boomify(new Error('oops'))).to.not.be.instanceOf(BadaBoom);
+        });
+
+        it('handles actual sub-class instances when called on sub-class', () => {
+
+            const BadaBoom = class extends Boom.Boom { };
+
+            expect(Object.create(BadaBoom.prototype)).to.be.instanceOf(BadaBoom);
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -127,12 +127,25 @@ describe('Boom', () => {
 
         it('identifies a boom object', () => {
 
+            const BadaBoom = class extends Boom.Boom { };
+
             expect(new Boom.Boom('oops') instanceof Boom.Boom).to.be.true();
+            expect(new BadaBoom('oops') instanceof Boom.Boom).to.be.true();
             expect(Boom.badRequest('oops') instanceof Boom.Boom).to.be.true();
             expect(new Error('oops') instanceof Boom.Boom).to.be.false();
             expect(Boom.boomify(new Error('oops')) instanceof Boom.Boom).to.be.true();
             expect({ isBoom: true } instanceof Boom.Boom).to.be.false();
             expect(null instanceof Boom.Boom).to.be.false();
+        });
+
+        it('returns false when called on sub-class', () => {
+
+            const BadaBoom = class extends Boom.Boom {};
+
+            expect(new Boom.Boom('oops') instanceof BadaBoom).to.be.false();
+            expect(new BadaBoom('oops') instanceof BadaBoom).to.be.false();
+            expect(Boom.badRequest('oops') instanceof BadaBoom).to.be.false();
+            expect(Boom.boomify(new Error('oops')) instanceof BadaBoom).to.be.false();
         });
     });
 


### PR DESCRIPTION
This should fix the false positives reported in #285. Now any `instanceof` check called on a `Boom` subclass will effectively return `false`, since the actual returned object from the constructor is _never_ a `Boom` object.

I used https://stackoverflow.com/a/57898482/248062 as input.