### PR TITLE
feat: allow boomifying any value (#291)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -153,6 +153,17 @@ export function isBoom(obj: unknown, statusCode?: number): obj is Boom;
 export function boomify<Data, Decoration>(err: Error, options?: Options<Data> & Decorate<Decoration>): Boom<Data> & Decoration;
 
 
+/**
+* Specifies if an error object is a valid boom object
+*
+* @param err - The error object to decorate
+* @param options - Options object
+*
+* @returns A decorated boom object
+*/
+export function boomifyAny<Data, Decoration>(err: unknown, options?: Options<Data> & Decorate<Decoration>): Boom<Data> & Decoration;
+
+
 // 4xx Errors
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,29 @@ exports.boomify = function (err, options) {
 };
 
 
+exports.boomifyAny = function (value, options) {
+
+    // Because message & statusCode are typically used for non-errors, override should not
+    // default to "true" when using boomifyAny with an error.
+    options = Object.assign({ override: false }, options);
+
+    if (value instanceof Error) {
+        return exports.boomify(value, options);
+    }
+
+    const err = new exports.Boom(options.message || 'Unknown error', { statusCode: options.statusCode || 500, data: value, ctor: exports.boomifyAny });
+
+    err.isDeveloperError = true;
+
+    if (options.decorate) {
+        Object.assign(err, options.decorate);
+    }
+
+    return err;
+
+};
+
+
 // 4xx Client Errors
 
 exports.badRequest = function (message, data) {


### PR DESCRIPTION
Creation of a new `boomifyAny` that allows creating a boom error from an `unknown` value.

This is a proposed fix for https://github.com/hapijs/boom/issues/291