### PR TITLE
Support node v18, drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v10
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ exports.boomify = function (err, options) {
     }
 
     if (!err.isBoom) {
-        return internals.initialize(err, options.statusCode || 500, options.message);
+        return internals.initialize(err, options.statusCode ?? 500, options.message);
     }
 
     if (options.override === false ||                           // Defaults to true
@@ -132,7 +132,7 @@ exports.boomify = function (err, options) {
         return err;
     }
 
-    return internals.initialize(err, options.statusCode || err.output.statusCode, options.message);
+    return internals.initialize(err, options.statusCode ?? err.output.statusCode, options.message);
 };
 
 
@@ -179,12 +179,7 @@ exports.unauthorized = function (message, scheme, attributes) {          // Or (
         else {
             wwwAuthenticate += ' ' + Object.keys(attributes).map((name) => {
 
-                let value = attributes[name];
-                if (value === null ||
-                    value === undefined) {
-
-                    value = '';
-                }
+                const value = attributes[name] ?? '';
 
                 err.output.payload.attributes[name] = value;
                 return `${name}="${Hoek.escapeHeaderAttribute(value.toString())}"`;

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x"
+    "@hapi/hoek": "10.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "25.0.0-beta.1",
+    "@types/node": "^17.0.30",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update typescript and node v18-compatible versions of lab and code.

If this looks good, this will go out as boom v10.